### PR TITLE
KomaListクラスの更新

### DIFF
--- a/KomaList.pde
+++ b/KomaList.pde
@@ -19,3 +19,21 @@ class KomaList {
     }
   }
 }
+AbstractKoma getSelectedKoma() {
+    for (AbstractKoma k : komaArray) {
+      if (k.kStat.selected) return k;
+    }
+    return null;
+  }
+
+  void select(int x, int y) {
+    AbstractKoma koma = this.getKomaFromPlaceByTeam(x, y, gs.turn);
+    if (koma != null) koma.kStat.selected=true;
+  }
+
+  AbstractKoma getKomaFromPlaceByTeam(int x, int y, int team) {
+    for (AbstractKoma k : this.komaArray) {
+      if (team==k.team && x == k.x && y == k.y && k.kStat.active) return k;
+    }
+    return null;
+  }


### PR DESCRIPTION
KomaListクラスに getSelectedKoma() メソッド， select() メソッドと getKomaFromPlaceByTeam() メソッドを追加する


• getSelectedKoma() メソッドでは，komaArrayにあるすべてのコマの中から，選択されているもの(kStat.selectedがtrueのもの）を探し，返す．
• select() メソッドでは，クリックされた座標(x,y)に，そのターンのチーム（Left/Right）に属するコマが存在したとき，そのコマのkStat.selectedをtrueに変更する．
• getKomaFromPlaceByTeam() メソッドはクリックされた座標(x,y)に存在するそのターンのチームに属するコマを返す．
•このタスクの下記 KomaList クラスの select メソッドにおいて， gs.turn の箇所でコンパイルエラーが発生する．このコンパイルエラーはTask3-5が完了しなければ取れない（GameStatusの宣言をDoubutsu.pdeで行っているため）．